### PR TITLE
Fix font locking for issue #9.

### DIFF
--- a/dylan-mode.el
+++ b/dylan-mode.el
@@ -524,9 +524,9 @@ using the values of the various keyword list variables."
   ;; and, optionally, all function calls.
   (setq dylan-font-lock-keywords-2
 	(append dylan-font-lock-keywords-1
-		'(("slot[ \t\n]+\\(\\w+\\)" 1 font-lock-function-name-face)
+		'(("slot[ \t\n]+\\(\\(\\sw\\|\\s_\\)+\\)" 1 font-lock-variable-name-face)
 		  ("block[ \t\n]+(\\([^)]+\\)" 1 font-lock-function-name-face)
-		  ("let[ \t\n]+\\(\\w+\\)" 1 font-lock-variable-name-face)
+		  ("let[ \t\n]+\\(\\(\\sw\\|\\s_\\)+\\)" 1 font-lock-variable-name-face)
 		  ;; This highlights commas and whitespace separating the
                   ;; variable names. Try to find a way to highlight only the
                   ;; variable names.


### PR DESCRIPTION
Makes it so that let foo-bar highlights foo-bar as a variable name
rather than just foo.

This change also changes the face for slot names to always be
font-lock-variable-name-face; there was a conflict with
another font lock rule (variable :: type) where if the slot had
a type, it would use -variable-name-face, but if not it would use
-function-name-face.

Fixes #9.

Signed-off-by: Erik Charlebois erikcharlebois@gmail.com
