### PR TITLE
Make 'define test' and 'define suite' indent/highlight correctly

### DIFF
--- a/dylan-mode.el
+++ b/dylan-mode.el
@@ -115,7 +115,9 @@ whitespace prefix."
 
 (defvar dylan-unnamed-definition-words
   '(;; Melange/C-FFI
-    "interface")
+    "interface"
+    ;; Testworks
+    "suite" "test")
   "Words that introduce unnamed definitions like \"define interface\".")
 
 (defvar dylan-named-definition-words


### PR DESCRIPTION
Any idea why this variable is called "unnamed"?