### PR TITLE
dylan-mode: Support module prefixes that end with '/'

### DIFF
--- a/dylan-mode-test.dylan
+++ b/dylan-mode-test.dylan
@@ -188,6 +188,9 @@ define function foo ()
   without-interrupts () body() end;
   printing-object (o, s) body() end;
   doing-this () body() end;
+  iterate a-loop ()
+    body()
+  end;
 end function;
 
 let 0d0 = x;    // *** 0d0 not valid name, shouldn't highlight.

--- a/dylan-mode-test.dylan
+++ b/dylan-mode-test.dylan
@@ -179,10 +179,15 @@ define inline-only function test-highlight-inline-only () end;
 define default-inline function test-highlight-default-inline () end;
 
 define function foo ()
-  with-open-file (stream = "/tmp/foo") end;
+  with-open-file (stream = "/tmp/foo")
+    body();
+  end;
+  file-system/with-open-file (stream = "/tmp/foo")
+    body()
+  end;
   without-interrupts () body() end;
-  printing-object (o, s) end;
-  doing-this () end;
+  printing-object (o, s) body() end;
+  doing-this () body() end;
 end function;
 
 let 0d0 = x;    // *** 0d0 not valid name, shouldn't highlight.

--- a/dylan-mode.el
+++ b/dylan-mode.el
@@ -219,9 +219,10 @@ simple definitions and are appended to `dylan-other-simple-definition-words'.")
   "Words that begin statements with implicit bodies.")
 
 ;; Names beginning "with-", "without-", and "...ing-" (e.g., printing-object)
-;; are commonly used as statement macros.
+;; are commonly used as statement macros. Also includes optional module prefix,
+;; with the assumption that the prefix is very simple and ends with '/'.
 (defvar dylan-with-statement-prefix
-  "\\(with\\|without\\|[a-zA-Z]+ing\\)-")
+  "\\([a-zA-Z-]+/\\)?\\(with\\|without\\|[a-zA-Z]+ing\\)-")
 
 (defvar dylan-statement-prefixes
   (concat "\\|\\_<" dylan-with-statement-prefix "[-_a-zA-Z?!*@<>$%]+"))

--- a/dylan-mode.el
+++ b/dylan-mode.el
@@ -467,7 +467,7 @@ using the values of the various keyword list variables."
           ("unless[ \t\n]*" "")
           ("until[ \t\n]*" "")
           ("while[ \t\n]*" "")
-          ("iterate[ \t\n]+\\w+[ \t\n]*" "")
+          ("iterate[ \t\n]+[a-zA-Z-]+[ \t\n]*" "")
           ("profiling[ \t\n]*" "")
           ;; Special patterns for "define method" and "define function", which
           ;; have a return value spec.


### PR DESCRIPTION
Works for "fs/" and "file-system/" but I didn't bother to try and support all
of dylan-name-pattern. Not sure how perfect to make the NAME matching regular
expressions. I have a general worry that they'll get too slow and/or that the
code will be much harder to maintain and it won't be worth the small benefit.
Perfect enemy of good etc.