### PR TITLE
Maintenance for Dylan LID mode

### DIFF
--- a/dime.el
+++ b/dime.el
@@ -75,7 +75,7 @@
 
 (require 'dime-compat)
 (require 'dylan-mode)
-(require 'dylanlid-mode)
+(require 'dylan-lid)
 (require 'dylan-optimization-coloring)
 
 (defvar dime-buffer-project nil)

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -3,7 +3,6 @@
 ;; Copyright (C) 2014 Erik Charlebois
 
 ;; Author: Erik Charlebois (erikcharlebois@gmail.com)
-;; Version: 1.00
 
 ;; This file is *NOT* part of GNU Emacs.
 

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -30,19 +30,6 @@
 
 ;;; Code:
 
-(defconst dylan-lid-version-number "1.00"
-  "Dylan LID Mode version number.")
-
-(defun dylan-lid-version ()
-  "Return string describing the version of Dylan LID mode.
-When called interactively, displays the version."
-  (interactive)
-  (let ((string (format "Dylan LID Mode version %s"
-                        dylan-lid-version-number)))
-    (when (called-interactively-p 'interactive)
-      (message "%s" string))
-    string))
-
 
 ;;; Customization:
 
@@ -190,9 +177,6 @@ See `dylan-lid-make-file-link'."
 
 May be customized with the options in the `dylan-lid' customization
 group.
-
-To see the current version of Dylan LID Mode, enter
-`\\[dylan-lid-version]'.
 
 This mode runs the hook `dylan-lid-mode-hook', as the final step
 during initialization."

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -26,8 +26,6 @@
 ;; Dylan LID mode is a major mode for editing LID files which define libraries
 ;; for the Dylan programming language. It provides indenting and
 ;; font-lock support.
-;;
-;; This code requires Emacs 24.
 
 
 ;;; Code:

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -101,7 +101,7 @@ whitespace prefix."
               "[^ \t\n]"                ; any invalid prefix character
               "[^\n]*\n")               ; rest of line
      . 'dylan-lid-error-face))
- "Value to which `font-lock-keywords' should be set when
+  "Value to which `font-lock-keywords' should be set when
 fontifying Dylan LID files in Dylan LID Mode.")
 
 
@@ -162,9 +162,9 @@ fontifying Dylan LID files in Dylan LID Mode.")
 
 (defun dylan-lid-make-lid-files-clickable ()
   "Apply modifications only to .lid files and avoid marking the file as changed."
-    (if (derived-mode-p 'dylan-lid-mode)
-        (with-silent-modifications
-          (dylan-lid-make-files-clickable))))
+  (if (derived-mode-p 'dylan-lid-mode)
+      (with-silent-modifications
+        (dylan-lid-make-files-clickable))))
 
 (defvar dylan-lid-timer-id nil "ID of the one-and-only timer")
 

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -39,9 +39,11 @@
   "Return string describing the version of Dylan LID mode.
 When called interactively, displays the version."
   (interactive)
-  (if (called-interactively-p 'interactive)
-      (message (dylan-lid-version))
-    (format "Dylan LID Mode version %s" dylan-lid-version-number)))
+  (let ((string (format "Dylan LID Mode version %s"
+                        dylan-lid-version-number)))
+    (when (called-interactively-p 'interactive)
+      (message "%s" string))
+    string))
 
 
 ;;; Customization:

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -1,7 +1,7 @@
 ;;; dylan-lid.el --- Major mode for Dylan LID files -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2014 Erik Charlebois
-
+;; SPDX-License-Identifier: GPL-1.0-or-later
 ;; Author: Erik Charlebois (erikcharlebois@gmail.com)
 
 ;; This file is *NOT* part of GNU Emacs.

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -1,4 +1,4 @@
-;;; dylanlid-mode.el --- Major mode for editing Dylan LID files.
+;;; dylan-lid.el --- Major mode for editing Dylan LID files.
 
 ;; Copyright (C) 2014 Erik Charlebois
 
@@ -33,49 +33,49 @@
 
 ;;; Code:
 
-(defconst dylanlid-version "1.00"
+(defconst dylan-lid-version-number "1.00"
   "Dylan LID Mode version number.")
 
-(defun dylanlid-version ()
+(defun dylan-lid-version ()
   "Return string describing the version of Dylan LID mode.
 When called interactively, displays the version."
   (interactive)
   (if (called-interactively-p 'interactive)
-      (message (dylanlid-version))
-    (format "Dylan LID Mode version %s" dylanlid-version)))
+      (message (dylan-lid-version))
+    (format "Dylan LID Mode version %s" dylan-lid-version-number)))
 
 
 ;;; Customization:
 
-(defgroup dylanlid nil
+(defgroup dylan-lid nil
   "Major mode for editing Dylan LID files."
   :group 'languages)
 
 
 ;;; Faces:
 
-(defface dylanlid-keyword
+(defface dylan-lid-keyword-face
   '((t :inherit font-lock-keyword-face))
   "Face for Dylan LID keywords."
-  :group 'dylanlid)
+  :group 'dylan-lid)
 
-(defface dylanlid-value
+(defface dylan-lid-value-face
   '((t))
   "Face for Dylan LID values."
-  :group 'dylanlid)
+  :group 'dylan-lid)
 
-(defface dylanlid-error
+(defface dylan-lid-error-face
   '((t :inherit font-lock-warning-face))
   "Face for invalid lines in Dylan LID files.
 
 Valid lines begin with a keyword or a value continuation
 whitespace prefix."
-  :group 'dylanlid)
+  :group 'dylan-lid)
 
 
 ;;; Regular expressions:
 
-(defvar dylanlid-font-lock-keywords
+(defvar dylan-lid-font-lock-keywords
   `(
     ;; Header lines with keywords, and lines with value continuations.
     (,(concat "^"
@@ -90,8 +90,8 @@ whitespace prefix."
 	      "[^ \t\n][^\n]*?"		; value
 	      "\\)"
 	      "[ \t]*\\(\n\\|\\'\\)")	; tail space
-     (1 'dylanlid-keyword nil t)
-     (2 'dylanlid-value))
+     (1 'dylan-lid-keyword-face nil t)
+     (2 'dylan-lid-value-face))
 
     ;; Invalid lines. This pattern assumes we've already tried the
     ;; pattern for header lines with keywords and it didn't match.
@@ -101,24 +101,24 @@ whitespace prefix."
     (,(concat "^"
 	      "[^ \t\n]"		; any invalid prefix character
 	      "[^\n]*\n")		; rest of line
-     . 'dylanlid-error))
+     . 'dylan-lid-error-face))
  "Value to which `font-lock-keywords' should be set when
 fontifying Dylan LID files in Dylan LID Mode.")
 
 
 ;;; Font locking:
 
-(defun dylanlid-font-lock-fontify-region (beg end loudly)
+(defun dylan-lid-font-lock-fontify-region (beg end loudly)
   "Dylan LID Mode font lock fontification."
   (let ((font-lock-dont-widen t)
-        (font-lock-keywords dylanlid-font-lock-keywords)
+        (font-lock-keywords dylan-lid-font-lock-keywords)
         (font-lock-keywords-only t))
     (font-lock-default-fontify-region beg end loudly)))
 
 
 ;;; Clickable files:
 
-(defun dylanlid-make-file-link (start end src-dir)
+(defun dylan-lid-make-file-link (start end src-dir)
   "Attempt to make the region between START and END into a
  clickable link to open a module for editing, with modules located
  relative to SRC-DIR"
@@ -140,7 +140,7 @@ fontifying Dylan LID files in Dylan LID Mode.")
         (put-text-property start end 'help-echo
                            "mouse-1: edit file")))))
 
-(defun dylanlid-make-files-clickable ()
+(defun dylan-lid-make-files-clickable ()
   "Make all modules with existing files clickable, where clicking opens them"
   (interactive)
   (remove-list-of-text-properties (point-min) (point-max)
@@ -157,22 +157,22 @@ fontifying Dylan LID files in Dylan LID Mode.")
             (let ((beg (match-beginning 0))
                   (end (match-end 0))
                   (src-dir (file-name-directory (buffer-file-name))))
-              (dylanlid-make-file-link beg end src-dir))
+              (dylan-lid-make-file-link beg end src-dir))
             (forward-line)
             (re-search-forward "\\s-*" nil t)))))))
 
-(defun dylanlid-make-lid-files-clickable ()
+(defun dylan-lid-make-lid-files-clickable ()
   "Apply modifications only to .lid files and avoid marking the file as changed."
-    (if (derived-mode-p 'dylanlid-mode)
+    (if (derived-mode-p 'dylan-lid-mode)
         (with-silent-modifications
-          (dylanlid-make-files-clickable))))
+          (dylan-lid-make-files-clickable))))
 
-(defvar dylanlid-timer-id nil "ID of the one-and-only timer")
+(defvar dylan-lid-timer-id nil "ID of the one-and-only timer")
 
 
-;;; dylanlid-mode:
+;;; dylan-lid-mode:
 
-(defvar dylanlid-mode-syntax-table
+(defvar dylan-lid-mode-syntax-table
   (let ((table (make-syntax-table prog-mode-syntax-table)))
     (modify-syntax-entry ?- "_" table)
     (modify-syntax-entry ?/ "_" table)
@@ -180,30 +180,30 @@ fontifying Dylan LID files in Dylan LID Mode.")
     table))
 
 ;;;###autoload
-(define-derived-mode dylanlid-mode prog-mode "Dylan LID"
+(define-derived-mode dylan-lid-mode prog-mode "Dylan LID"
   "Major mode for editing Dylan LID files.
 
-May be customized with the options in the `dylanlid' customization
+May be customized with the options in the `dylan-lid' customization
 group.
 
 To see the current version of Dylan LID Mode, enter
-`\\[dylanlid-version]'.
+`\\[dylan-lid-version]'.
 
-This mode runs the hook `dylanlid-mode-hook', as the final step
+This mode runs the hook `dylan-lid-mode-hook', as the final step
 during initialization."
   (setq-local parse-sexp-lookup-properties t)
   (setq-local font-lock-defaults
-              `(dylanlid-font-lock-keywords
+              `(dylan-lid-font-lock-keywords
                 nil t nil nil
                 (font-lock-fontify-region-function
-                 . dylanlid-font-lock-fontify-region)))
-  (unless dylanlid-timer-id
-    (setq dylanlid-timer-id (run-with-idle-timer 1 t 'dylanlid-make-lid-files-clickable))))
+                 . dylan-lid-font-lock-fontify-region)))
+  (unless dylan-lid-timer-id
+    (setq dylan-lid-timer-id (run-with-idle-timer 1 t 'dylan-lid-make-lid-files-clickable))))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.lid\\'" . dylanlid-mode))
+(add-to-list 'auto-mode-alist '("\\.lid\\'" . dylan-lid-mode))
 
 
-(provide 'dylanlid-mode)
+(provide 'dylan-lid)
 
-;;; dylanlid-mode.el ends here
+;;; dylan-lid.el ends here

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -101,14 +101,15 @@ whitespace prefix."
               "[^ \t\n]"                ; any invalid prefix character
               "[^\n]*\n")               ; rest of line
      . 'dylan-lid-error-face))
-  "Value to which `font-lock-keywords' should be set when
-fontifying Dylan LID files in Dylan LID Mode.")
+  "Font lock keywords for ‘dylan-lid--mode’.  See ‘font-lock-keywords’.")
 
 
 ;;; Font locking:
 
 (defun dylan-lid-font-lock-fontify-region (beg end loudly)
-  "Dylan LID Mode font lock fontification."
+  "Fontify a region of a Dylan LID Mode buffer.
+
+The arguments BEG, END, LOUDLY are as for `font-lock-fontify-region'."
   (let ((font-lock-dont-widen t)
         (font-lock-keywords dylan-lid-font-lock-keywords)
         (font-lock-keywords-only t))
@@ -118,9 +119,11 @@ fontifying Dylan LID files in Dylan LID Mode.")
 ;;; Clickable files:
 
 (defun dylan-lid-make-file-link (start end src-dir)
-  "Attempt to make the region between START and END into a
- clickable link to open a module for editing, with modules located
- relative to SRC-DIR"
+  "Turn the region between START and END into a clickable link.
+
+If the region points to an existing a Dylan module, make it a
+link that opens that module for editing. Modules are located
+relative to SRC-DIR."
   (let* ((name (buffer-substring-no-properties start end))
          (fname (split-string name "\\."))
          (basename (concat (mapconcat 'file-name-as-directory
@@ -140,7 +143,9 @@ fontifying Dylan LID files in Dylan LID Mode.")
                            "mouse-1: edit file")))))
 
 (defun dylan-lid-make-files-clickable ()
-  "Make all modules with existing files clickable, where clicking opens them"
+  "Make all modules with existing files clickable.
+
+See `dylan-lid-make-file-link'."
   (interactive)
   (remove-list-of-text-properties (point-min) (point-max)
                                   '(keymap mouse-face help-echo))
@@ -166,7 +171,8 @@ fontifying Dylan LID files in Dylan LID Mode.")
       (with-silent-modifications
         (dylan-lid-make-files-clickable))))
 
-(defvar dylan-lid-timer-id nil "ID of the one-and-only timer")
+(defvar dylan-lid-timer-id nil
+  "ID of the global Dylan LID timer.")
 
 
 ;;; dylan-lid-mode:

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -78,17 +78,17 @@ whitespace prefix."
   `(
     ;; Header lines with keywords, and lines with value continuations.
     (,(concat "^"
-	      "\\(?:\\("
-	      "[a-zA-Z][-a-zA-Z0-9]*:"	; keyword...
-	      "\\)\\|"
-	      "[ \t]"			; ...or continuation prefix
-	      "\\)"
-	      "[ \t]*"			; space
-	      "\\("
-	      ;; Can keyword lines have empty values?
-	      "[^ \t\n][^\n]*?"		; value
-	      "\\)"
-	      "[ \t]*\\(\n\\|\\'\\)")	; tail space
+              "\\(?:\\("
+              "[a-zA-Z][-a-zA-Z0-9]*:"  ; keyword...
+              "\\)\\|"
+              "[ \t]"                   ; ...or continuation prefix
+              "\\)"
+              "[ \t]*"                  ; space
+              "\\("
+              ;; Can keyword lines have empty values?
+              "[^ \t\n][^\n]*?"         ; value
+              "\\)"
+              "[ \t]*\\(\n\\|\\'\\)")   ; tail space
      (1 'dylan-lid-keyword-face nil t)
      (2 'dylan-lid-value-face))
 
@@ -98,8 +98,8 @@ whitespace prefix."
     ;; Note: Ideally, we'd mark any subsequent continuation lines invalid,
     ;; too. Look into a way to do that.
     (,(concat "^"
-	      "[^ \t\n]"		; any invalid prefix character
-	      "[^\n]*\n")		; rest of line
+              "[^ \t\n]"                ; any invalid prefix character
+              "[^\n]*\n")               ; rest of line
      . 'dylan-lid-error-face))
  "Value to which `font-lock-keywords' should be set when
 fontifying Dylan LID files in Dylan LID Mode.")
@@ -148,7 +148,7 @@ fontifying Dylan LID files in Dylan LID Mode.")
     (goto-char (point-min))
     (save-match-data
       (when (re-search-forward "^Files:\\s-*" nil t)
-	(let ((bound nil))
+        (let ((bound nil))
           (save-excursion
             (when (re-search-forward "^[a-zA-Z0-9\\-]+\\s-*:" nil t)
               (setq bound (match-beginning 0))))

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -1,4 +1,4 @@
-;;; dylan-lid.el --- Major mode for editing Dylan LID files.
+;;; dylan-lid.el --- Major mode for Dylan LID files -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2014 Erik Charlebois
 
@@ -130,8 +130,8 @@ fontifying Dylan LID files in Dylan LID Mode.")
                            (car (last fname))))
          (dylan (concat basename ".dylan")))
     (when (file-exists-p dylan)
-      (lexical-let ((map (make-sparse-keymap))
-                    (src-file dylan))
+      (let ((map (make-sparse-keymap))
+            (src-file dylan))
         (define-key map [mouse-1]
           (lambda ()
             (interactive)
@@ -150,7 +150,7 @@ fontifying Dylan LID files in Dylan LID Mode.")
     (goto-char (point-min))
     (save-match-data
       (when (re-search-forward "^Files:\\s-*" nil t)
-	(lexical-let ((bound nil))
+	(let ((bound nil))
           (save-excursion
             (when (re-search-forward "^[a-zA-Z0-9\\-]+\\s-*:" nil t)
               (setq bound (match-beginning 0))))

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -94,7 +94,7 @@ whitespace prefix."
 ;;; Font locking:
 
 (defun dylan-lid-font-lock-fontify-region (beg end loudly)
-  "Fontify a region of a Dylan LID Mode buffer.
+  "Fontify region in Dylan LID buffer.
 
 The arguments BEG, END, LOUDLY are as for `font-lock-fontify-region'."
   (let ((font-lock-dont-widen t)
@@ -106,11 +106,11 @@ The arguments BEG, END, LOUDLY are as for `font-lock-fontify-region'."
 ;;; Clickable files:
 
 (defun dylan-lid-make-file-link (start end src-dir)
-  "Turn the region between START and END into a clickable link.
+  "Turn region between START and END into clickable link.
 
-If the region points to an existing a Dylan module, make it a
-link that opens that module for editing. Modules are located
-relative to SRC-DIR."
+If the region points to an existing Dylan module, make it a link
+that opens that module for editing. Modules are located relative
+to SRC-DIR."
   (let* ((name (buffer-substring-no-properties start end))
          (fname (split-string name "\\."))
          (basename (concat (mapconcat 'file-name-as-directory
@@ -130,7 +130,7 @@ relative to SRC-DIR."
                            "mouse-1: edit file")))))
 
 (defun dylan-lid-make-files-clickable ()
-  "Make all modules with existing files clickable.
+  "Turn all Dylan modules with existing files into clickable links.
 
 See `dylan-lid-make-file-link'."
   (interactive)
@@ -153,7 +153,12 @@ See `dylan-lid-make-file-link'."
             (re-search-forward "\\s-*" nil t)))))))
 
 (defun dylan-lid-make-lid-files-clickable ()
-  "Apply modifications only to .lid files and avoid marking the file as changed."
+  "Turn all Dylan modules with existing files into clickable links.
+
+Apply modifications only to `dylan-lid-mode' buffers and avoid
+marking the buffers as modified.
+
+See `dylan-lid-make-file-link'."
   (if (derived-mode-p 'dylan-lid-mode)
       (with-silent-modifications
         (dylan-lid-make-files-clickable))))


### PR DESCRIPTION
Starting off with the easiest file, here's the first batch of commits. I checked that it:

* compiles without warnings on Emacs 25.1
* satisfies `M-x checkdoc`
* satisfies `M-x package-lint-current-buffer` as far as applicable