### PR TITLE
doc: Point to OD docs instead of repeating things here

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `dylan` package (Dylan editing modes):
   optimizations.
 * `dylan-lid.el` -- The `dylan-lid-mode` major mode to edit LID files.
 
-The `dime` package (Dylan interaction mode, an IDE derived from
+The `dime` package (Dylan Interactor Mode for Emacs), an IDE derived from
 [SLIME](https://common-lisp.net/project/slime/)):
 
 * `dime.el` -- Interactive development environment.
@@ -18,19 +18,7 @@ The `dime` package (Dylan interaction mode, an IDE derived from
 * `dime-browse.el` -- Class browser.
 * `dime-note-tree.el` -- Compiler note browser.
 
-## Setting up Dime
+## Using DIME
 
-Dime relies on a backend, `dswank`. To configure Dime and `dswank`,
-add these lines to your .emacs file, changing `YYYY.nn` as appropriate
-for your installed release of Open Dylan::
-
-```lisp
-(dime-setup '(dime-repl dime-note-tree))
-(setq dime-dylan-implementations
-      '((opendylan ("/opt/opendylan-YYYY.nn/bin/dswank")
-                    :env ("OPEN_DYLAN_USER_REGISTRIES=/opt/opendylan-YYYY.nn/sources/registry"))))
-```
-
-You will also want to add your own source registries to the
-`OPEN_DYLAN_USER_REGISTRIES` environment variable. Registry paths are
-separated by semicolons on Windows and colons elsewhere.
+DIME documentation is currently included as part of the Open Dylan project,
+[here](https://opendylan.org/getting-started-cli/dylan-mode-for-emacs.html).


### PR DESCRIPTION
Ultimately I think we should move the docs to this repository and in the OD docs point to https://package.opendylan.org/dylan-emacs-support but that's more than I want to do right now.